### PR TITLE
Fixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,4 +8,4 @@ name = "pypi"
 [dev-packages]
 
 [requires]
-python_version = "3.9"
+python_version = "3.*"

--- a/tenis/states/gameplay.py
+++ b/tenis/states/gameplay.py
@@ -100,7 +100,10 @@ class GamePlay(State):
             self.__reset(screen)        
 
     def __start(self):
-        SoundMannager.instance().play_music(cfg_item("music", "music", "audio_file"))        
+        try:
+            SoundMannager.instance().play_music(cfg_item("music", "music", "audio_file"))  
+        except:
+            print("Sound output device not found")   
 
     def exit(self):
         pass


### PR DESCRIPTION
- Pipenv instalation adapted to all python3 versions, not just 3.9.
- If you didn't had headphones, the library mixed crashed, solved handling exceptions.